### PR TITLE
Reverse-engineer MTK IRadio interfaces to approve incoming call for MTK devices from Telephony F/W.

### DIFF
--- a/vendor/mediatek/hardware/radio/2.0/Android.bp
+++ b/vendor/mediatek/hardware/radio/2.0/Android.bp
@@ -4,12 +4,20 @@ hidl_interface {
     name: "vendor.mediatek.hardware.radio@2.0",
     root: "vendor",
     srcs: [
+        "types.hal",
         "IRadio.hal",
+        "IRadioIndication.hal",
+        "IRadioResponse.hal",
     ],
     interfaces: [
         "android.hardware.radio@1.0",
         "android.hardware.radio@1.1",
         "android.hidl.base@1.0",
+    ],
+    types: [
+        "IncomingCallNotification",
+        "MtkDataProfileInfo",
+        "MtkSetupDataCallResult",
     ],
     gen_java: true,
 }

--- a/vendor/mediatek/hardware/radio/2.0/IRadio.hal
+++ b/vendor/mediatek/hardware/radio/2.0/IRadio.hal
@@ -1,16 +1,18 @@
 package vendor.mediatek.hardware.radio@2.0;
 
 import android.hardware.radio@1.1::IRadio;
+import vendor.mediatek.hardware.radio@2.0::IRadioResponse;
+import vendor.mediatek.hardware.radio@2.0::IRadioIndication;
 
 interface IRadio extends android.hardware.radio@1.1::IRadio {
-	setResponseFunctionMtk(); //setResponseFunctionMtk(IRadioResponse responseCb, IRadioIndication indicationCb);
-	setResponseFunctionIms(); //setResponseFunctionIms(IImsRadioResponse reseponseCb, IImsRadioIndication indicationCb);
+	setResponseFunctionsMtk(IRadioResponse responseCb, IRadioIndication indicationCb); //setResponseFunctionMtk(IRadioResponse responseCb, IRadioIndication indicationCb);
+	setResponseFunctionsIms(); //setResponseFunctionIms(IImsRadioResponse reseponseCb, IImsRadioIndication indicationCb);
 
 	oneway setTrm(); // oneway setTrm(int32_t, int32_t);
 	oneway getATR(); // oneway getATR(int32_t);
 	oneway setSimPower(); // oneway setSimPower(int32_t, int32_t);
 	oneway hangupAll(); // oneway hangupAll(int32_t);
-	oneway setCallIndication(); // oneway setCallIndication(int32_t, int32_t, int32_t, int32_t);
+	oneway setCallIndication(int32_t serial, int32_t mode, int32_t callId, int32_t seqNo); // oneway setCallIndication(int32_t, int32_t, int32_t, int32_t);
 	oneway emergencyDial(); // oneway emergencyDial(int32_t, Dial);
 	oneway setEccServiceCategory(); // oneway setEccServiceCategory(int32_t, int32_t);
 	oneway setEccList(); // oneway setEccList(int32_t, string, string);

--- a/vendor/mediatek/hardware/radio/2.0/IRadioIndication.hal
+++ b/vendor/mediatek/hardware/radio/2.0/IRadioIndication.hal
@@ -1,0 +1,71 @@
+package vendor.mediatek.hardware.radio@2.0;
+
+import android.hardware.radio@1.1::IRadioIndication;
+import android.hardware.radio@1.0::RadioIndicationType;
+
+interface IRadioIndication extends android.hardware.radio@1.1::IRadioIndication {
+        oneway incomingCallIndication(RadioIndicationType type, IncomingCallNotification notification);	// 49: incomingCallIndication(ILvendor/mediatek/hardware/radio/V2_0/IncomingCallNotification;)V
+        oneway cipherIndication();	// 50: cipherIndication(ILvendor/mediatek/hardware/radio/V2_0/CipherNotification;)V
+        oneway crssIndication();	// 51: crssIndication(ILvendor/mediatek/hardware/radio/V2_0/CrssNotification;)V
+        oneway vtStatusInfoIndication();	// 52: vtStatusInfoIndication(II)V
+        oneway speechCodecInfoIndication();	// 53: speechCodecInfoIndication(II)V
+        oneway cdmaCallAccepted();	// 54: cdmaCallAccepted(I)V
+        oneway onVirtualSimOn();	// 55: onVirtualSimOn(II)V
+        oneway onVirtualSimOff();	// 56: onVirtualSimOff(II)V
+        oneway onImeiLock();	// 57: onImeiLock(I)V
+        oneway onImsiRefreshDone();	// 58: onImsiRefreshDone(I)V
+        oneway newEtwsInd();	// 59: newEtwsInd(ILvendor/mediatek/hardware/radio/V2_0/EtwsNotification;)V
+        oneway meSmsStorageFullInd();	// 60: meSmsStorageFullInd(I)V
+        oneway smsReadyInd();	// 61: smsReadyInd(I)V
+        oneway dataCallListChangedEx(RadioIndicationType type, vec<MtkSetupDataCallResult> dcResponse);	// 62: dataCallListChangedEx(ILjava/util/ArrayList;)V
+        oneway responseCsNetworkStateChangeInd();	// 63: responseCsNetworkStateChangeInd(ILjava/util/ArrayList;)V
+        oneway eMBMSAtInfoIndication();	// 64: eMBMSAtInfoIndication(ILjava/lang/String;)V
+        oneway eMBMSSessionStatusIndication();	// 65: eMBMSSessionStatusIndication(II)V
+        oneway responsePsNetworkStateChangeInd();	// 66: responsePsNetworkStateChangeInd(ILjava/util/ArrayList;)V
+        oneway responseInvalidSimInd();	// 67: responseInvalidSimInd(ILjava/util/ArrayList;)V
+        oneway responseNetworkEventInd();	// 68: responseNetworkEventInd(ILjava/util/ArrayList;)V
+        oneway responseModulationInfoInd();	// 69: responseModulationInfoInd(ILjava/util/ArrayList;)V
+        oneway dataAllowedNotification();	// 70: dataAllowedNotification(II)V
+        oneway onPseudoCellInfoInd();	// 71: onPseudoCellInfoInd(ILjava/util/ArrayList;)V
+        oneway plmnChangedIndication();	// 72: plmnChangedIndication(ILjava/util/ArrayList;)V
+        oneway registrationSuspendedIndication();	// 73: registrationSuspendedIndication(ILjava/util/ArrayList;)V
+        oneway gmssRatChangedIndication();	// 74: gmssRatChangedIndication(ILjava/util/ArrayList;)V
+        oneway worldModeChangedIndication();	// 75: worldModeChangedIndication(ILjava/util/ArrayList;)V
+        oneway resetAttachApnInd();	// 76: resetAttachApnInd(I)V
+        oneway mdChangedApnInd();	// 77: mdChangedApnInd(II)V
+        oneway esnMeidChangeInd();	// 78: esnMeidChangeInd(ILjava/lang/String;)V
+        oneway responseFemtocellInfo();	// 79: responseFemtocellInfo(ILjava/util/ArrayList;)V
+        oneway phbReadyNotification();	// 80: phbReadyNotification(II)V
+        oneway bipProactiveCommand();	// 81: bipProactiveCommand(ILjava/lang/String;)V
+        oneway triggerOtaSP();	// 82: triggerOtaSP(I)V
+        oneway onStkMenuReset();	// 83: onStkMenuReset(I)V
+        oneway onMdDataRetryCountReset();	// 84: onMdDataRetryCountReset(I)V
+        oneway onRemoveRestrictEutran();	// 85: onRemoveRestrictEutran(I)V
+        oneway onPcoStatus();	// 86: onPcoStatus(ILjava/util/ArrayList;)V
+        oneway onLteAccessStratumStateChanged();	// 87: onLteAccessStratumStateChanged(ILjava/util/ArrayList;)V
+        oneway onSimPlugIn();	// 88: onSimPlugIn(I)V
+        oneway onSimPlugOut();	// 89: onSimPlugOut(I)V
+        oneway onSimMissing();	// 90: onSimMissing(II)V
+        oneway onSimRecovery();	// 91: onSimRecovery(II)V
+        oneway onSimTrayPlugIn();	// 92: onSimTrayPlugIn(I)V
+        oneway onSimCommonSlotNoChanged();	// 93: onSimCommonSlotNoChanged(I)V
+        oneway onSimMeLockEvent();	// 94: onSimMeLockEvent(I)V
+        oneway networkInfoInd();	// 95: networkInfoInd(ILjava/util/ArrayList;)V
+        oneway cfuStatusNotify();	// 96: cfuStatusNotify(ILvendor/mediatek/hardware/radio/V2_0/CfuStatusNotification;)V
+        oneway pcoDataAfterAttached();	// 97: pcoDataAfterAttached(ILvendor/mediatek/hardware/radio/V2_0/PcoDataAttachedInfo;)V
+        oneway confSRVCC();	// 98: confSRVCC(ILjava/util/ArrayList;)V
+        oneway onVsimEventIndication();	// 99: onVsimEventIndication(ILvendor/mediatek/hardware/radio/V2_0/VsimOperationEvent;)V
+        oneway volteLteConnectionStatus();	// 100: volteLteConnectionStatus(ILjava/util/ArrayList;)V
+        oneway dedicatedBearerActivationInd();	// 101: dedicatedBearerActivationInd(ILvendor/mediatek/hardware/radio/V2_0/DedicateDataCall;)V
+        oneway dedicatedBearerModificationInd();	// 102: dedicatedBearerModificationInd(ILvendor/mediatek/hardware/radio/V2_0/DedicateDataCall;)V
+        oneway dedicatedBearerDeactivationInd();	// 103: dedicatedBearerDeactivationInd(II)V
+        oneway onWifiMonitoringThreshouldChanged();	// 104: onWifiMonitoringThreshouldChanged(ILjava/util/ArrayList;)V
+        oneway onWifiPdnActivate();	// 105: onWifiPdnActivate(ILjava/util/ArrayList;)V
+        oneway onWfcPdnError();	// 106: onWfcPdnError(ILjava/util/ArrayList;)V
+        oneway onPdnHandover();	// 107: onPdnHandover(ILjava/util/ArrayList;)V
+        oneway onWifiRoveout();	// 108: onWifiRoveout(ILjava/util/ArrayList;)V
+        oneway onLocationRequest();	// 109: onLocationRequest(ILjava/util/ArrayList;)V
+        oneway onWfcPdnStateChanged();	// 110: onWfcPdnStateChanged(ILjava/util/ArrayList;)V
+        oneway onNattKeepAliveChanged();	// 111: onNattKeepAliveChanged(ILjava/util/ArrayList;)V
+        oneway oemHookRaw();	// 112: oemHookRaw(ILjava/util/ArrayList;)V
+};

--- a/vendor/mediatek/hardware/radio/2.0/IRadioResponse.hal
+++ b/vendor/mediatek/hardware/radio/2.0/IRadioResponse.hal
@@ -1,0 +1,105 @@
+package vendor.mediatek.hardware.radio@2.0;
+
+import android.hardware.radio@1.1::IRadioResponse;
+import android.hardware.radio@1.0::RadioResponseInfo;
+
+interface IRadioResponse extends android.hardware.radio@1.1::IRadioResponse {
+        oneway setTrmResponse();	// 136: setTrmResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway getATRResponse();	// 137: getATRResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;Ljava/lang/String;)V
+        oneway setSimPowerResponse();	// 138: setSimPowerResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway setModemPowerResponse();	// 139: setModemPowerResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway hangupAllResponse();	// 140: hangupAllResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway setCallIndicationResponse(RadioResponseInfo info);	// 141: setCallIndicationResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway emergencyDialResponse();	// 142: emergencyDialResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway setEccServiceCategoryResponse();	// 143: setEccServiceCategoryResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway setEccListResponse();	// 144: setEccListResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway vtDialResponse();	// 145: vtDialResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway voiceAcceptResponse();	// 146: voiceAcceptResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway replaceVtCallResponse();	// 147: replaceVtCallResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway setNetworkSelectionModeManualWithActResponse();	// 148: setNetworkSelectionModeManualWithActResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway getAvailableNetworksWithActResponse();	// 149: getAvailableNetworksWithActResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;Ljava/util/ArrayList;)V
+        oneway cancelAvailableNetworksResponse();	// 150: cancelAvailableNetworksResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway currentStatusResponse();	// 151: currentStatusResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway eccPreferredRatResponse();	// 152: eccPreferredRatResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway getSmsParametersResponse();	// 153: getSmsParametersResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;Lvendor/mediatek/hardware/radio/V2_0/SmsParams;)V
+        oneway setSmsParametersResponse();	// 154: setSmsParametersResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway getSmsMemStatusResponse();	// 155: getSmsMemStatusResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;Lvendor/mediatek/hardware/radio/V2_0/SmsMemStatus;)V
+        oneway setEtwsResponse();	// 156: setEtwsResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway removeCbMsgResponse();	// 157: removeCbMsgResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway setGsmBroadcastLangsResponse();	// 158: setGsmBroadcastLangsResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway getGsmBroadcastLangsResponse();	// 159: getGsmBroadcastLangsResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;Ljava/lang/String;)V
+        oneway getGsmBroadcastActivationRsp();	// 160: getGsmBroadcastActivationRsp(Landroid/hardware/radio/V1_0/RadioResponseInfo;I)V
+        oneway sendEmbmsAtCommandResponse();	// 161: sendEmbmsAtCommandResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;Ljava/lang/String;)V
+        oneway setupDataCallResponseEx(RadioResponseInfo info, MtkSetupDataCallResult setupDataCallResult);	// 162: setupDataCallResponseEx(Landroid/hardware/radio/V1_0/RadioResponseInfo;Lvendor/mediatek/hardware/radio/V2_0/MtkSetupDataCallResult;)V
+        oneway getDataCallListResponseEx(RadioResponseInfo info, vec<MtkSetupDataCallResult> dcResponse);	// 163: getDataCallListResponseEx(Landroid/hardware/radio/V1_0/RadioResponseInfo;Ljava/util/ArrayList;)V
+        oneway setApcModeResponse();	// 164: setApcModeResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway getApcInfoResponse();	// 165: getApcInfoResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;Ljava/util/ArrayList;)V
+        oneway triggerModeSwitchByEccResponse();	// 166: triggerModeSwitchByEccResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway getSmsRuimMemoryStatusResponse();	// 167: getSmsRuimMemoryStatusResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;Lvendor/mediatek/hardware/radio/V2_0/SmsMemStatus;)V
+        oneway setFdModeResponse();	// 168: setFdModeResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway setResumeRegistrationResponse();	// 169: setResumeRegistrationResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway storeModemTypeResponse();	// 170: storeModemTypeResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway reloadModemTypeResponse();	// 171: reloadModemTypeResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway handleStkCallSetupRequestFromSimWithResCodeResponse();	// 172: handleStkCallSetupRequestFromSimWithResCodeResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway getFemtocellListResponse();	// 173: getFemtocellListResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;Ljava/util/ArrayList;)V
+        oneway abortFemtocellListResponse();	// 174: abortFemtocellListResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway selectFemtocellResponse();	// 175: selectFemtocellResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway queryFemtoCellSystemSelectionModeResponse();	// 176: queryFemtoCellSystemSelectionModeResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;I)V
+        oneway setFemtoCellSystemSelectionModeResponse();	// 177: setFemtoCellSystemSelectionModeResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway setClipResponse();	// 178: setClipResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway getColpResponse();	// 179: getColpResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;II)V
+        oneway getColrResponse();	// 180: getColrResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;I)V
+        oneway sendCnapResponse();	// 181: sendCnapResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;II)V
+        oneway setColpResponse();	// 182: setColpResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway setColrResponse();	// 183: setColrResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway queryCallForwardInTimeSlotStatusResponse();	// 184: queryCallForwardInTimeSlotStatusResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;Ljava/util/ArrayList;)V
+        oneway setCallForwardInTimeSlotResponse();	// 185: setCallForwardInTimeSlotResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway runGbaAuthenticationResponse();	// 186: runGbaAuthenticationResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;Ljava/util/ArrayList;)V
+        oneway queryPhbStorageInfoResponse();	// 187: queryPhbStorageInfoResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;Ljava/util/ArrayList;)V
+        oneway writePhbEntryResponse();	// 188: writePhbEntryResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway readPhbEntryResponse();	// 189: readPhbEntryResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;Ljava/util/ArrayList;)V
+        oneway queryUPBCapabilityResponse();	// 190: queryUPBCapabilityResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;Ljava/util/ArrayList;)V
+        oneway editUPBEntryResponse();	// 191: editUPBEntryResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway deleteUPBEntryResponse();	// 192: deleteUPBEntryResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway readUPBGasListResponse();	// 193: readUPBGasListResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;Ljava/util/ArrayList;)V
+        oneway readUPBGrpEntryResponse();	// 194: readUPBGrpEntryResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;Ljava/util/ArrayList;)V
+        oneway writeUPBGrpEntryResponse();	// 195: writeUPBGrpEntryResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway getPhoneBookStringsLengthResponse();	// 196: getPhoneBookStringsLengthResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;Ljava/util/ArrayList;)V
+        oneway getPhoneBookMemStorageResponse();	// 197: getPhoneBookMemStorageResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;Lvendor/mediatek/hardware/radio/V2_0/PhbMemStorageResponse;)V
+        oneway setPhoneBookMemStorageResponse();	// 198: setPhoneBookMemStorageResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway readPhoneBookEntryExtResponse();	// 199: readPhoneBookEntryExtResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;Ljava/util/ArrayList;)V
+        oneway writePhoneBookEntryExtResponse();	// 200: writePhoneBookEntryExtResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway queryUPBAvailableResponse();	// 201: queryUPBAvailableResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;Ljava/util/ArrayList;)V
+        oneway readUPBEmailEntryResponse();	// 202: readUPBEmailEntryResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;Ljava/lang/String;)V
+        oneway readUPBSneEntryResponse();	// 203: readUPBSneEntryResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;Ljava/lang/String;)V
+        oneway readUPBAnrEntryResponse();	// 204: readUPBAnrEntryResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;Ljava/util/ArrayList;)V
+        oneway readUPBAasListResponse();	// 205: readUPBAasListResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;Ljava/util/ArrayList;)V
+        oneway queryNetworkLockResponse();	// 206: queryNetworkLockResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;IIIIIII)V
+        oneway setNetworkLockResponse();	// 207: setNetworkLockResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway resetRadioResponse();	// 208: resetRadioResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway syncDataSettingsToMdResponse();	// 209: syncDataSettingsToMdResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway resetMdDataRetryCountResponse();	// 210: resetMdDataRetryCountResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway setRemoveRestrictEutranModeResponse();	// 211: setRemoveRestrictEutranModeResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway setLteAccessStratumReportResponse();	// 212: setLteAccessStratumReportResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway setLteUplinkDataTransferResponse();	// 213: setLteUplinkDataTransferResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway setRxTestConfigResponse();	// 214: setRxTestConfigResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;Ljava/util/ArrayList;)V
+        oneway getRxTestResultResponse();	// 215: getRxTestResultResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;Ljava/util/ArrayList;)V
+        oneway getPOLCapabilityResponse();	// 216: getPOLCapabilityResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;Ljava/util/ArrayList;)V
+        oneway getCurrentPOLListResponse();	// 217: getCurrentPOLListResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;Ljava/util/ArrayList;)V
+        oneway setPOLEntryResponse();	// 218: setPOLEntryResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway setRoamingEnableResponse();	// 219: setRoamingEnableResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway getRoamingEnableResponse();	// 220: getRoamingEnableResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;Ljava/util/ArrayList;)V
+        oneway vsimNotificationResponse();	// 221: vsimNotificationResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;Lvendor/mediatek/hardware/radio/V2_0/VsimEvent;)V
+        oneway vsimOperationResponse();	// 222: vsimOperationResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway setWifiEnabledResponse();	// 223: setWifiEnabledResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway setWifiAssociatedResponse();	// 224: setWifiAssociatedResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway setWifiSignalLevelResponse();	// 225: setWifiSignalLevelResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway setWifiIpAddressResponse();	// 226: setWifiIpAddressResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway setLocationInfoResponse();	// 227: setLocationInfoResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway setEmergencyAddressIdResponse();	// 228: setEmergencyAddressIdResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway setNattKeepAliveStatusResponse();	// 229: setNattKeepAliveStatusResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway setE911StateResponse();	// 230: setE911StateResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway setServiceStateToModemResponse();	// 231: setServiceStateToModemResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;)V
+        oneway sendRequestRawResponse();	// 232: sendRequestRawResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;Ljava/util/ArrayList;)V
+        oneway sendRequestStringsResponse();	// 233: sendRequestStringsResponse(Landroid/hardware/radio/V1_0/RadioResponseInfo;Ljava/util/ArrayList;)V
+};

--- a/vendor/mediatek/hardware/radio/2.0/types.hal
+++ b/vendor/mediatek/hardware/radio/2.0/types.hal
@@ -6,3 +6,19 @@ struct MtkDataProfileInfo {
 	android.hardware.radio@1.0::DataProfileInfo dpi;
 	int32_t inactiveTimer;
 };
+
+struct IncomingCallNotification {
+    string callId;
+    string number;
+    string type;
+    string callMode;
+    string seqNo;
+    string redirectNumber;
+    string toNumber;
+};
+
+struct MtkSetupDataCallResult {
+    android.hardware.radio@1.0::SetupDataCallResult dcr;
+    int32_t rat;
+};
+


### PR DESCRIPTION
This is an alternative solution of 's/AT+EAIC=2/AT+EAIC=3/g' in device/phh/treble/rw-system.sh
which is not workable on some MTK devices such as Nokia 1.
Make sure that the solution in `rw-system.sh` is reversed if this alternative is applied.

Here is the reason of each API to be reverse-engineered in this patch:
1. IRadio::setResponseFunctionsMtk():
   - To register callbacks of MTK-extended radio indications and responses.
2. IRadioIndication::incomingCallIndication():
   - To receive the indication of the incoming call to be approved.
3. IRadio::setCallIndication() |
   IRadioResponse::setCallIndicationResponse():
   - To approve each the incoming call reported from incomingCallIndication().
4. IRadioResponse::setupDataCallResponseEx() |
   IRadioResponse::getDataCallListResponseEx() |
   IRadioIndication::dataCallListChangedEx():
   - These callbacks are MTK's replacements of the following AOSP callbacks:
     setupDataCallResponse(), getDataCallListResponse(), dataCallListChanged() if
     MTK-specific implementation is registered via IRadio::setResponseFunctionsMtk().
   - To make sure that data connections are workable after fixing the incoming call issues,
     we have to implement these methods additionally to forward the responses to the replaced ones defined by AOSP.